### PR TITLE
Rename instances of thundernest to thunderbird.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+thunderbird-ansible.key
 thundernest-ansible.key
 *.retry
 *.pyc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 2. Open the terminal and enter the following commands:
 3. `sudo apt-get install ansible git-crypt`
 4. `pip install linode-python`.
-5. `git clone https://github.com/thundernest/thundernest-ansible.git`
+5. `git clone https://github.com/thunderbird/thundernest-ansible.git`
 6. `ansible-galaxy install geerlingguy.apache`
 7. Get the `thundernest-ansible.key` from 1password, labeled `git-crypt key for thundernest-ansible`.
 8. Get the `thundernest-infra` RSA key labeled `Linode ssh private key` from 1password. Copy it to ~/.ssh, `chmod 600 thundernest-infra` and `mv thundernest-infra id_rsa`.
@@ -51,7 +51,7 @@ Once you have confirmed all of this, you can follow the steps below to set your 
 
 # What if the SSL certs are expired?
 
-1. The SSL certs are stored in [thundernest-ansible/files](https://github.com/thundernest/thundernest-ansible/tree/master/files).
+1. The SSL certs are stored in [thundernest-ansible/files](https://github.com/thunderbird/thundernest-ansible/tree/master/files).
 2. They are normally renewed automatically on the 21st of each month, and committed to the repository.
 3. To renew them manually:
 ```bash

--- a/plays/autoconfig-deploy.yml
+++ b/plays/autoconfig-deploy.yml
@@ -11,7 +11,7 @@
 
     - name: checkout autoconfig
       git:
-        repo: "https://github.com/thundernest/autoconfig.git"
+        repo: "https://github.com/thunderbird/autoconfig.git"
         dest: "{{ autoconfig_trunk }}"
         version: "{{ branch | default('prod') }}"
 

--- a/plays/broker-deploy.yml
+++ b/plays/broker-deploy.yml
@@ -6,7 +6,7 @@
   tasks:
   - name: checkout broker
     git:
-      repo: "https://github.com/thundernest/broker.git"
+      repo: "https://github.com/thunderbird/broker.git"
       dest: "{{ brokerdest }}"
       version: "{{ branch | default('prod') }}"
       force: yes

--- a/plays/control-apache.yml
+++ b/plays/control-apache.yml
@@ -18,7 +18,7 @@
     - name: checkout webhook
       become: yes
       git:
-        repo: "https://github.com/thundernest/python-github-webhooks"
+        repo: "https://github.com/thunderbird/python-github-webhooks"
         dest: "/var/www/deployhook"
         force: True
 

--- a/plays/control-install.yml
+++ b/plays/control-install.yml
@@ -52,7 +52,7 @@
 
     - name: checkout ansible files
       git:
-        repo: "https://github.com/thundernest/thundernest-ansible.git"
+        repo: "https://github.com/thunderbird/thundernest-ansible.git"
         dest: "{{ homedir }}/thundernest-ansible"
 
     - name: install thundernest-ansible requirements
@@ -99,7 +99,7 @@
 
     - name: checkout tb website
       git:
-        repo: "https://github.com/thundernest/thunderbird-website.git"
+        repo: "https://github.com/thunderbird/thunderbird-website.git"
         dest: "{{ homedir }}/thunderbird-website"
 
     - name: Force install old version because pip is insane.

--- a/plays/http-mx-deploy.yml
+++ b/plays/http-mx-deploy.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: checkout the mx service
       git:
-        repo: "https://github.com/thundernest/http-mx.git"
+        repo: "https://github.com/thunderbird/http-mx.git"
         dest: "{{ mxdest }}"
         version: "{{ branch | default('prod') }}"
 

--- a/plays/live-redirects-deploy.yml
+++ b/plays/live-redirects-deploy.yml
@@ -11,7 +11,7 @@
 
     - name: checkout the live redirects
       git:
-        repo: "https://github.com/thundernest/live-redirects.git"
+        repo: "https://github.com/thunderbird/live-redirects.git"
         dest: "{{ live_doc_root }}"
         version: "{{ branch | default('prod') }}"
         force: True

--- a/plays/start-deploy.yml
+++ b/plays/start-deploy.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: checkout tb-website-builds to get the start page files
       git:
-        repo: "https://github.com/thundernest/tb-website-builds.git"
+        repo: "https://github.com/thunderbird/tb-website-builds.git"
         dest: "{{ start_page_files }}"
         version: "{{ branch | default('prod') }}"
         force: True

--- a/plays/static-test-deploy.yml
+++ b/plays/static-test-deploy.yml
@@ -6,6 +6,6 @@
   tasks:
     - name: checkout the static-test files
       git:
-        repo: "https://github.com/thundernest/static-test.git"
+        repo: "https://github.com/thunderbird/static-test.git"
         dest: "{{ statictestdest }}"
         version: "{{ branch | default('main') }}"

--- a/plays/stats-deploy.yml
+++ b/plays/stats-deploy.yml
@@ -8,7 +8,7 @@
   tasks:
   - name: checkout stats
     git:
-      repo: "https://github.com/thundernest/stats.git"
+      repo: "https://github.com/thunderbird/stats.git"
       dest: "{{ stats_files }}"
       version: "{{ branch | default('prod') }}"
       force: true

--- a/plays/style-deploy.yml
+++ b/plays/style-deploy.yml
@@ -6,6 +6,6 @@
   tasks:
   - name: checkout style-guide repo
     git:
-      repo: "https://github.com/thundernest/style-guide.git"
+      repo: "https://github.com/thunderbird/style-guide.git"
       dest: "{{ style_files }}"
       version: "{{ branch | default('prod') }}"

--- a/plays/website-build.yml
+++ b/plays/website-build.yml
@@ -24,27 +24,27 @@
 
     - name: checkout tb-website-builds history repo
       git:
-        repo: "https://github.com/thundernest/tb-website-builds.git"
+        repo: "https://github.com/thunderbird/tb-website-builds.git"
         dest: "{{ tbsitebuild }}"
         version: "{{ branch | default('master') }}"
         depth: 1
 
     - name: checkout thunderbird-website
       git:
-        repo: "https://github.com/thundernest/thunderbird-website.git"
+        repo: "https://github.com/thunderbird/thunderbird-website.git"
         dest: "{{ tbsite }}"
         version: "{{ branch | default('master') }}"
 
     - name: checkout Mozilla localization files
       git:
-        repo: "https://github.com/thundernest/thunderbird.net-l10n.git"
+        repo: "https://github.com/thunderbird/thunderbird.net-l10n.git"
         dest: "{{ tbsite }}{{ locale }}"
         version: "master"
         depth: 1
 
     - name: checkout release notes
       git:
-        repo: "https://github.com/thundernest/thunderbird-notes.git"
+        repo: "https://github.com/thunderbird/thunderbird-notes.git"
         dest: "{{ tbsite }}{{ notes }}"
         version: "{{ branch | default('master') }}"
 
@@ -99,7 +99,7 @@
         - "git -c 'user.name=Thundernest Bot' -c 'user.email={{ lookup('env', 'GIT_EMAIL') }}' commit -m 'Website rebuild triggered by {{ message | default('manual execution of the script.') }}'"
 
     - name: push website update
-      command: "git push https://{{ lookup('env', 'GIT_USER') | urlencode }}:{{ lookup('env', 'GIT_API_KEY') }}@github.com/thundernest/tb-website-builds.git --all"
+      command: "git push https://{{ lookup('env', 'GIT_USER') | urlencode }}:{{ lookup('env', 'GIT_API_KEY') }}@github.com/thunderbird/tb-website-builds.git --all"
       args:
         chdir: "{{ tbsitebuild }}"
 

--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -160,15 +160,15 @@ apache_vhosts:
       WSGIProcessGroup stage.thunderbird.net
 
       RewriteRule ^/(.*)/thunderbird/60\.0/whatsnew/$ https://support.mozilla.org/$1/kb/new-thunderbird-60 [R=302,L]
-      # https://github.com/thundernest/thunderbird-website/issues/162
+      # https://github.com/thunderbird/thunderbird-website/issues/162
       RewriteRule ^/ja-JP-mac/?(.*)$ /ja/$1 [R=302]
-      # https://github.com/thundernest/thunderbird.net-l10n/issues/1
+      # https://github.com/thunderbird/thunderbird.net-l10n/issues/1
       RewriteRule ^/bn-(?:BD|IN)/?(.*)$ /bn/$1 [R=302]
       RewriteRule ^/privacy/? https://www.mozilla.org/privacy/thunderbird/ [R=302]
       RewriteRule ^/thunderbird/(latest/)?system-requirements/? /system-requirements/ [R=302]
       RewriteRule ^/thunderbird/notes/? /notes/ [R=302]
       RewriteRule ^/releases/? /thunderbird/releases/ [R=302]
-      # https://github.com/thundernest/thunderbird-website/issues/160
+      # https://github.com/thunderbird/thunderbird-website/issues/160
       RewriteRule ^(.*)/channel/? #channel [R=302,NE]
       # URLs with no language code need to be assigned one by wsgi.py
       WSGIScriptAliasMatch ^/$ /var/www/html/start/wsgi.py
@@ -195,9 +195,9 @@ apache_vhosts:
       ExpiresActive On
       ExpiresDefault "access plus 8 hours"
       RewriteEngine On
-      # https://github.com/thundernest/thunderbird-website/issues/162
+      # https://github.com/thunderbird/thunderbird-website/issues/162
       RewriteRule ^/ja-JP-mac/?(.*)$ /ja/$1 [R=302]
-      # https://github.com/thundernest/thunderbird.net-l10n/issues/1
+      # https://github.com/thunderbird/thunderbird.net-l10n/issues/1
       RewriteRule ^/bn-(?:BD|IN)/?(.*)$ /bn/$1 [R=302]
       RewriteRule ^/$ /en-US/release/ [R=302]
       Header always set Strict-Transport-Security "max-age=31536000"


### PR DESCRIPTION
This has a small checklist to..check before we merge:
- [x] Ensure all git repos referenced by scripts are moved over.
- [x] Ensure tb-website-build won't break if we change the git user from Thundernest bot to Thunderbird bot.
- [x] Ensure thundernest-infra is renamed to thunderbird-infra in 1password.
- [x] Ensure `root_ssh_pub_key` in conf.yaml is correct after the rename.
- [x] Ensure thundernest-ansible.key is renamed to thunderbird-ansible.key in 1password.

I've kept the thundernest-ansible.key in .gitignore just in case. But I've added the eventual thunderbird-ansible.key. 
