### PR TITLE
Adjusted redirects for thunderbird-website redesign

### DIFF
--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -182,6 +182,8 @@ apache_vhosts:
       WSGIScriptAliasMatch ^/thunderbird /var/www/html/start/wsgi.py
       # This is the link that thunderbird.net currently uses for the careers page
       RewriteRule ^/careers/? https://www.mozilla.org/careers/listings/?team=MZLA%2FThunderbird [R=302,L]
+      # Temp redirect, pending a new page on thunderbird.netß
+      RewriteRule ^/organizations/? https://wiki.mozilla.org/Thunderbird/Enterprise [r=302,L]  
       # Link still exists in Thunderbird, so lets just redirect them to participate and homepage
       RewriteRule ^/get-involved/? /participate/ [R=302]
       RewriteRule ^/features/? / [R=302]

--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -181,6 +181,9 @@ apache_vhosts:
       WSGIScriptAliasMatch ^/thunderbird /var/www/html/start/wsgi.py
       # This is the link that thunderbird.net currently uses for the careers page
       RewriteRule ^/careers/? https://www.mozilla.org/careers/listings/?team=MZLA%2FThunderbird [R=302,L]
+      # Link still exists in Thunderbird, so lets just redirect them to participate and homepage
+      RewriteRule ^/get-involved/? /participate/ [R=302]
+      RewriteRule ^/features/? / [R=302]
       ExpiresActive On
       ExpiresDefault "access plus 2 hours"
       Header always set Strict-Transport-Security "max-age=31536000"

--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -173,17 +173,14 @@ apache_vhosts:
       # URLs with no language code need to be assigned one by wsgi.py
       WSGIScriptAliasMatch ^/$ /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/about[/]?$ /var/www/html/start/wsgi.py
+      WSGIScriptAliasMatch ^/contact /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/donate /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/download /var/www/html/start/wsgi.py
-      WSGIScriptAliasMatch ^/features[/]?$ /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/newsletter /var/www/html/start/wsgi.py
-      WSGIScriptAliasMatch ^/organizations[/]?$ /var/www/html/start/wsgi.py
+      WSGIScriptAliasMatch ^/participate /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/thunderbird /var/www/html/start/wsgi.py
-      RewriteRule ^/calendar/?(.*)$ /en-US/calendar/$1 [R=302]
-      RewriteRule ^/careers/? /en-US/careers/ [R=302]
-      RewriteRule ^/contact/? /en-US/contact/ [R=302]
-      RewriteRule ^/email-providers/? /en-US/email-providers/ [R=302]
-      RewriteRule ^/get-involved/? /en-US/get-involved/ [R=302]
+      # This is the link that thunderbird.net currently uses for the careers page
+      RewriteRule ^/careers/? https://www.mozilla.org/careers/listings/?team=MZLA%2FThunderbird [R=302,L]
       ExpiresActive On
       ExpiresDefault "access plus 2 hours"
       Header always set Strict-Transport-Security "max-age=31536000"

--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -178,6 +178,7 @@ apache_vhosts:
       WSGIScriptAliasMatch ^/download /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/newsletter /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/participate /var/www/html/start/wsgi.py
+      WSGIScriptAliasMatch ^/survey /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/thunderbird /var/www/html/start/wsgi.py
       # This is the link that thunderbird.net currently uses for the careers page
       RewriteRule ^/careers/? https://www.mozilla.org/careers/listings/?team=MZLA%2FThunderbird [R=302,L]


### PR DESCRIPTION
We don't have any english-only routes except for release notes anymore, so nuked those. Also cleaned up some soon-to-be dead links.

Added a careers redirect to the link we use on thunderbird.net, and added participate. 

Let me know if I've missed anything!

This should go live on the 16th. 