### PR TITLE
Add a legacy redirect to the donation faq.

### DIFF
--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -266,6 +266,10 @@ apache_vhosts:
     extra_parameters: |
       ExpiresActive On
       ExpiresDefault "access plus 24 hours"
+      <Location "/help">
+        RewriteEngine On
+        RewriteRule .* https://www.thunderbird.net/donate/#faq [R=302]
+      </Location>
       <Location />
         RewriteEngine On
         RewriteRule .* https://www.thunderbird.net/donate/ [R=302]


### PR DESCRIPTION
We have some old links that point to give.thunderbird.net/help. We should point them directly to the faq. 

This isn't the highest priority since we've moved the faq up, but a direct link probably would be appreciated. 