### PR TITLE
Add redirects for privacy control support articles

### DIFF
--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -101,6 +101,10 @@ apache_vhosts:
       RewriteRule (.*) https://support.mozilla.org/kb/thunderbird-add-ons-frequently-asked-questions [L]
       RewriteCond %{REQUEST_URI} ^/thunderbird/([^/]+)/([^/]+)/([^/]+)/extension-permissions$
       RewriteRule (.*) https://support.mozilla.org/kb/permission-request-messages-thunderbird-extensions [L]
+      RewriteCond %{REQUEST_URI} ^/thunderbird/([^/]+)/([^/]+)/([^/]+)/global-privacy-control$
+      RewriteRule (.*) https://support.mozilla.org/kb/global-privacy-control [L]
+      RewriteCond %{REQUEST_URI} ^/thunderbird/([^/]+)/([^/]+)/([^/]+)/how-do-i-turn-do-not-track-feature$
+      RewriteRule (.*) https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature [L]
       RewriteCond %{REQUEST_URI} ^/kb/ask$
       RewriteRule (.*) https://support.mozilla.org/en-US/questions/new/thunderbird [L]
       RewriteCond %{REQUEST_URI} ^/([^/]+)/kb/ask$


### PR DESCRIPTION
These redirects are for porting the changes from Firefox in https://phabricator.services.mozilla.com/D232149

For now we redirect to the same articles as Firefox, but pinging @rtanglao in case we want to change that in the future.